### PR TITLE
Ignore Oracle messages for detecting validator updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "fcd",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.10.6",
+      "version": "0.10.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcd",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Terra FCD Suite",
   "main": "index.js",
   "author": "Terra Engineering <engineering@terra.money>",

--- a/src/collector/dashboard/collectDashboard.ts
+++ b/src/collector/dashboard/collectDashboard.ts
@@ -35,7 +35,7 @@ export async function collectDashboard(updateExisting = false) {
 
     if (dashboard) {
       if (!updateExisting) {
-        logger.info(`Dashboard data of date ${dayIt} already exists`)
+        logger.info(`Dashboard exists: ${dayIt.toISOString()}`)
         continue
       }
     } else {
@@ -47,21 +47,21 @@ export async function collectDashboard(updateExisting = false) {
     dashboard.timestamp = dayIt
     dashboard.chainId = config.CHAIN_ID
     dashboard.txVolume = transactionVol[dateKey]
-    dashboard.reward = stakingReturn[dateKey].reward
-    dashboard.avgStaking = stakingReturn[dateKey].avgStaking
+    dashboard.reward = stakingReturn[dateKey]?.reward
+    dashboard.avgStaking = stakingReturn[dateKey]?.avgStaking
     dashboard.taxReward = taxRewards[dateKey]
-    dashboard.activeAccount = accountGrowth[dateKey].activeAccount
-    dashboard.totalAccount = accountGrowth[dateKey].totalAccount
+    dashboard.activeAccount = accountGrowth[dateKey]?.activeAccount
+    dashboard.totalAccount = accountGrowth[dateKey]?.totalAccount
 
     await getRepository(DashboardEntity)
       .save(dashboard)
       .then(() => {
-        logger.info(`Saved dashboard of ${dayIt.toISOString()}`)
+        logger.info(`Dashboard saved: ${dayIt.toISOString()}`)
       })
       .catch((error) => {
-        logger.error(`${error.message} failed to save dashboard of ${dayIt}`)
+        logger.error(`Dashboard save failed: ${dayIt.toISOString()} ${error.message}`)
       })
   }
 
-  logger.info('dashboard collector finished')
+  logger.info('Dashboard collector finished')
 }

--- a/src/collector/watcher.ts
+++ b/src/collector/watcher.ts
@@ -24,16 +24,9 @@ async function detectValidators(txs: Tx[]) {
   // extract validator addresses from string
   const addresses = uniq(
     txs
-      .filter((tx: any) => {
-        const msgs = tx?.value?.msg
-
-        if (!Array.isArray(msgs)) {
-          return false
-        }
-
-        // Ignore oracle tx
-        return msgs.filter((msg) => typeof msg.type === 'string' && msg.type.includes('oracle/')).length === 0
-      })
+      .filter((tx: any) =>
+        (tx?.value?.msg ?? []).some((msg) => typeof msg.type === 'string' && !msg.type.includes('oracle/'))
+      )
       .map((tx) => JSON.stringify(tx).match(VALIDATOR_REGEX))
       .flat()
       .filter(Boolean) as string[]

--- a/src/collector/watcher.ts
+++ b/src/collector/watcher.ts
@@ -24,6 +24,16 @@ async function detectValidators(txs: Tx[]) {
   // extract validator addresses from string
   const addresses = uniq(
     txs
+      .filter((tx: any) => {
+        const msgs = tx?.value?.msg
+
+        if (!Array.isArray(msgs)) {
+          return false
+        }
+
+        // Ignore oracle tx
+        return msgs.filter((msg) => typeof msg.type === 'string' && msg.type.includes('oracle/')).length === 0
+      })
       .map((tx) => JSON.stringify(tx).match(VALIDATOR_REGEX))
       .flat()
       .filter(Boolean) as string[]

--- a/src/orm/DashboardEntity.ts
+++ b/src/orm/DashboardEntity.ts
@@ -12,7 +12,7 @@ export default class DashboardEntity {
   @Column()
   chainId: string
 
-  @Column({ type: 'jsonb' })
+  @Column({ type: 'jsonb', default: '{}' })
   txVolume: DenomMap
 
   @Column('decimal', { precision: 40, scale: 10, default: '0' })


### PR DESCRIPTION
## Problem
Curretnly, we are detecting terravaloper... from transaction by regular expression for detecting which validator should be updated. Validators are doing oracle votes per 5 heights and because of this, collector is doing excessive updates.

## Update
Since Oracle has nothing to do with validator statistics we are displaying, we can filter out tx that has `oracle/` message inside.
