### PR TITLE
add user agent header to request-promise

### DIFF
--- a/src/lib/lcd.ts
+++ b/src/lib/lcd.ts
@@ -21,7 +21,8 @@ async function get(url: string, params?: { [key: string]: string | undefined }):
     method: 'GET',
     rejectUnauthorized: false,
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      'User-Agent': 'terra-fcd'
     },
     qs: params,
     json: true,

--- a/src/scripts/indexBlockProposer.ts
+++ b/src/scripts/indexBlockProposer.ts
@@ -31,6 +31,13 @@ async function main() {
 
   // do 1,000 updates at a time
   await Bluebird.mapSeries(chunk(heights, 1000), async (chk) => {
+    const options = {
+      json: true,
+      headers: {
+          'User-Agent': 'terra-fcd'
+      }
+    }
+
     const lcdDatas = await Bluebird.map(
       chk,
       async (height) => rp(`${config.LCD_URI}/blocks/${height}`, { json: true }),

--- a/src/scripts/indexBlockProposer.ts
+++ b/src/scripts/indexBlockProposer.ts
@@ -40,7 +40,7 @@ async function main() {
 
     const lcdDatas = await Bluebird.map(
       chk,
-      async (height) => rp(`${config.LCD_URI}/blocks/${height}`, { json: true }),
+      async (height) => rp(`${config.LCD_URI}/blocks/${height}`, options),
       {
         concurrency: 16
       }

--- a/src/scripts/mergeSwaggerFile.ts
+++ b/src/scripts/mergeSwaggerFile.ts
@@ -89,7 +89,13 @@ function normalizeSwagger(doc: Swagger): Swagger {
 }
 
 async function getLcdSwaggerObject(): Promise<Swagger> {
-  const doc = yaml.load(await rp(LCD_SWAGGER_URL))
+  const options = {
+    headers: {
+      'User-Agent': 'terra-fcd'
+    }
+  }
+
+  const doc = yaml.load(await rp(LCD_SWAGGER_URL, options))
   return filterExcludedRoutes(normalizeSwagger(doc))
 }
 


### PR DESCRIPTION
missing UA is a standard rule in most of the web application firewalls, requests from fcd will get immediately blocked