### PR TITLE
fix: add missing order param to getTxList API validation rules

### DIFF
--- a/src/controller/TransactionController.ts
+++ b/src/controller/TransactionController.ts
@@ -94,7 +94,7 @@ export default class TransactionController extends KoaController {
    * @apiParam {string} [chainId] Chain ID of Blockchain (default: chain id of mainnet)
    * @apiParam {number} [offset] Use next property from previous result for pagination
    * @apiParam {number} [limit=10,100] Size of page
-   * @apiParam {string=asc,desc} [order] Sort order. (default: asc)
+   * @apiParam {string=asc,desc} [order] Sort order. (default: asc if block param is given, otherwise desc)
    *
    * @apiSuccess {number} limit Size of page
    * @apiSuccess {number} next Offset of next page
@@ -166,7 +166,7 @@ export default class TransactionController extends KoaController {
       limit: Joi.number().default(10).valid(10, 100).description('Items per page'),
       offset: Joi.alternatives(Joi.number(), Joi.string()).description('Offset'),
       compact: Joi.boolean().description('Compact mode'),
-      order: Joi.string().default('ASC').valid('ASC', 'DESC').insensitive().description('Sort Order')
+      order: Joi.string().allow('').valid('ASC', 'DESC').insensitive().description('Sort Order')
     },
     failure: ErrorCodes.INVALID_REQUEST_ERROR
   })

--- a/src/controller/TransactionController.ts
+++ b/src/controller/TransactionController.ts
@@ -94,6 +94,7 @@ export default class TransactionController extends KoaController {
    * @apiParam {string} [chainId] Chain ID of Blockchain (default: chain id of mainnet)
    * @apiParam {number} [offset] Use next property from previous result for pagination
    * @apiParam {number} [limit=10,100] Size of page
+   * @apiParam {string=asc,desc} [order] Sort order. (default: asc)
    *
    * @apiSuccess {number} limit Size of page
    * @apiSuccess {number} next Offset of next page
@@ -164,7 +165,8 @@ export default class TransactionController extends KoaController {
       chainId: Joi.string().default(config.CHAIN_ID).regex(CHAIN_ID_REGEX),
       limit: Joi.number().default(10).valid(10, 100).description('Items per page'),
       offset: Joi.alternatives(Joi.number(), Joi.string()).description('Offset'),
-      compact: Joi.boolean().description('Compact mode')
+      compact: Joi.boolean().description('Compact mode'),
+      order: Joi.string().default('ASC').valid('ASC', 'DESC').insensitive().description('Sort Order')
     },
     failure: ErrorCodes.INVALID_REQUEST_ERROR
   })


### PR DESCRIPTION
## Background

 * [The `order` parameter in `getTxList`](https://github.com/terra-money/fcd/blob/c781bb151c2169b29c790c32be418449260e8e94/src/service/transaction/getTxList.ts#L9) was implemented but wasn't able to use it actually because the parameter was omitted from the API validation rules.

## Changes

 * This fixes a bug that `getTxList` API rejecting `order` query parameter.