### PR TITLE
[WIP] fix(collector/wasm): handle intra-block instantiation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9645,9 +9645,9 @@
       }
     },
     "node_modules/urijs": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.8.tgz",
-      "integrity": "sha512-iIXHrjomQ0ZCuDRy44wRbyTZVnfVNLVo3Ksz1yxNyE5wV1IDZW2S5Jszy45DTlw/UdsnRT7DyDhIz7Gy+vJumw=="
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.9.tgz",
+      "integrity": "sha512-v0V+v5F3NQFt6TX0GpA2NKyrpythDJI+PHRo66sUIDP/U6cXbm6NqLVcXylQGwiwW5VYNj+OAei3EU0ALj9AWg=="
     },
     "node_modules/url-parse-lax": {
       "version": "3.0.0",
@@ -17389,9 +17389,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.8.tgz",
-      "integrity": "sha512-iIXHrjomQ0ZCuDRy44wRbyTZVnfVNLVo3Ksz1yxNyE5wV1IDZW2S5Jszy45DTlw/UdsnRT7DyDhIz7Gy+vJumw=="
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.9.tgz",
+      "integrity": "sha512-v0V+v5F3NQFt6TX0GpA2NKyrpythDJI+PHRo66sUIDP/U6cXbm6NqLVcXylQGwiwW5VYNj+OAei3EU0ALj9AWg=="
     },
     "url-parse-lax": {
       "version": "3.0.0",


### PR DESCRIPTION
- a contract may be instantiated & executed within the same block.
- psql transaction will fail due to duplicate unique key
- mitigate by having a temporary map of contract addresses that first came known in this block