### PR TITLE
fix: null public_key

### DIFF
--- a/src/lib/lcd.ts
+++ b/src/lib/lcd.ts
@@ -115,9 +115,9 @@ export async function getTx(hash: string): Promise<Transaction.LcdTransaction | 
         signatures: auth_info.signer_infos.map((si, idx) => ({
           pub_key: {
             type: 'tendermint/PubKeySecp256k1',
-            value: si?.public_key.key || ''
+            value: si.public_key?.key || null
           },
-          signature: signatures[idx] || ''
+          signature: signatures[idx]
         })),
         memo: body.memo,
         timeout_height: body.timeout_height

--- a/src/lib/lcd.ts
+++ b/src/lib/lcd.ts
@@ -117,7 +117,7 @@ export async function getTx(hash: string): Promise<Transaction.LcdTransaction | 
             type: 'tendermint/PubKeySecp256k1',
             value: si?.public_key.key || ''
           },
-          signature: signatures[idx]
+          signature: signatures[idx] || ''
         })),
         memo: body.memo,
         timeout_height: body.timeout_height

--- a/src/lib/lcd.ts
+++ b/src/lib/lcd.ts
@@ -115,7 +115,7 @@ export async function getTx(hash: string): Promise<Transaction.LcdTransaction | 
         signatures: auth_info.signer_infos.map((si, idx) => ({
           pub_key: {
             type: 'tendermint/PubKeySecp256k1',
-            value: si.public_key.key
+            value: si?.public_key.key || ''
           },
           signature: signatures[idx]
         })),


### PR DESCRIPTION
Sending txs with public_key being null is a perfectly legit operation.

Ref:
- https://github.com/cosmos/cosmos-sdk/blob/v0.44.6/x/auth/ante/sigverify.go#L70; public_key is only needed upon the first interaction from an address. After this point pubkey will be set in db. The set record from db will be used against sigverify afterwards
- https://github.com/cosmos/cosmos-sdk/blob/v0.44.6/x/auth/ante/sigverify.go#L161; and the subsequent subroutines will pull addresses from each message then get public_key from db to verify against signature